### PR TITLE
Align Vapi model payload with Google Calendar API tools

### DIFF
--- a/src/routes/GoogleRoute.ts
+++ b/src/routes/GoogleRoute.ts
@@ -21,6 +21,16 @@ router.post(
     controller.scheduleEvent.bind(controller)
 );
 
+router.post(
+    "/availability",
+    controller.checkAvailability.bind(controller)
+);
+
+router.post(
+    "/cancel",
+    controller.cancelEvent.bind(controller)
+);
+
 router.delete(
     "/disconnect",
     authenticateToken,


### PR DESCRIPTION
## Summary
- restructure the Vapi assistant model payload to include company context messages and API request tools pointing at Google Calendar endpoints
- add REST handlers for checking availability and cancelling events while updating the Google service cancellation flow

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da97e4c184832799ce7224655d6709