### PR TITLE
Add call logging and call detail endpoints

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,5 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  setupFiles: ['<rootDir>/test/jest.setup.ts'],
 };

--- a/src/business/services/CallLogService.ts
+++ b/src/business/services/CallLogService.ts
@@ -1,0 +1,64 @@
+// src/business/services/CallLogService.ts
+import { inject, injectable } from "tsyringe";
+import { ICallLogRepository } from "../../data/interfaces/ICallLogRepository";
+import { VapiClient } from "../../clients/VapiClient";
+
+export type CallDetailsResponse = {
+    callSid: string;
+    fromNumber: string | null;
+    vapiCallId: string | null;
+    startedAt: Date;
+    endedAt: Date | null;
+    vapiDetails: unknown;
+};
+
+@injectable()
+export class CallLogService {
+    constructor(
+        @inject("ICallLogRepository") private readonly callLogRepository: ICallLogRepository,
+        @inject(VapiClient) private readonly vapiClient: VapiClient
+    ) {}
+
+    public async recordCallSession(
+        companyId: bigint,
+        callSid: string,
+        fromNumber: string | null,
+        vapiCallId: string | null,
+        startedAt: Date,
+        endedAt: Date
+    ): Promise<void> {
+        await this.callLogRepository.upsertCallLog(
+            companyId,
+            callSid,
+            fromNumber,
+            vapiCallId,
+            startedAt,
+            endedAt
+        );
+    }
+
+    public async getCallerNumbers(companyId: bigint, limit?: number): Promise<string[]> {
+        return this.callLogRepository.getDistinctCallerNumbers(companyId, limit ?? 50);
+    }
+
+    public async getCallDetails(companyId: bigint, callSid: string): Promise<CallDetailsResponse> {
+        const record = await this.callLogRepository.getCallBySid(companyId, callSid);
+        if (!record) {
+            throw new Error("Call not found for the specified company.");
+        }
+
+        if (!record.vapiCallId) {
+            throw new Error("No Vapi call ID stored for this call.");
+        }
+
+        const details = await this.vapiClient.fetchCallDetails(record.vapiCallId);
+        return {
+            callSid: record.callSid,
+            fromNumber: record.fromNumber,
+            vapiCallId: record.vapiCallId,
+            startedAt: record.startedAt,
+            endedAt: record.endedAt,
+            vapiDetails: details,
+        };
+    }
+}

--- a/src/clients/VapiClient.ts
+++ b/src/clients/VapiClient.ts
@@ -588,7 +588,7 @@ export class VapiClient {
   public async openRealtimeSession(
     callSid: string,
     callbacks: VapiRealtimeCallbacks,
-  ): Promise<VapiRealtimeSession> {
+  ): Promise<{ session: VapiRealtimeSession; callId: string | null }> {
     const config = this.currentConfig;
     if (!config || !this.company || !this.replyStyle || !this.companyContext || !this.schedulingContext) {
       throw new Error('Company must be configured before opening a Vapi session');
@@ -670,7 +670,7 @@ export class VapiClient {
       callbacks.onSessionError?.(error as Error);
     });
 
-    return session;
+    return { session, callId: callId ?? null };
   }
 
   private async establishRealtimeSocket(
@@ -1394,6 +1394,17 @@ export class VapiClient {
       const logger = level === 'warn' ? console.warn : console.error;
       logger(context, error);
     }
+  }
+
+  public async fetchCallDetails(callId: string): Promise<any> {
+    const normalized = (callId ?? '').toString().trim();
+    if (!normalized) {
+      throw new Error('A valid Vapi call ID is required to fetch call details.');
+    }
+
+    const path = this.buildApiPath(`/call/${encodeURIComponent(normalized)}`);
+    const response = await this.http.get(path);
+    return response.data;
   }
 }
 

--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -28,6 +28,9 @@ import { AssistantSyncService } from "../business/services/AssistantSyncService"
 import { UsageService } from "../business/services/UsageService";
 import { IUsageRepository } from "../data/interfaces/IUsageRepository";
 import { UsageRepository } from "../data/repositories/UsageRepository";
+import { CallLogService } from "../business/services/CallLogService";
+import { ICallLogRepository } from "../data/interfaces/ICallLogRepository";
+import { CallLogRepository } from "../data/repositories/CallLogRepository";
 
 // Register all clients in the container
 container.register(VapiClient, { useClass: VapiClient });
@@ -52,6 +55,7 @@ container.register(UpdateService, { useClass: UpdateService });
 container.register(SchedulingService, { useClass: SchedulingService });
 container.register(AssistantSyncService, { useClass: AssistantSyncService });
 container.register(UsageService, { useClass: UsageService });
+container.register(CallLogService, { useClass: CallLogService });
 
 // Register data repositories
 container.register<ICompanyRepository>("ICompanyRepository", {
@@ -80,4 +84,7 @@ container.register<ISchedulingRepository>("ISchedulingRepository", {
 })
 container.register<IUsageRepository>("IUsageRepository", {
     useClass: UsageRepository,
+})
+container.register<ICallLogRepository>("ICallLogRepository", {
+    useClass: CallLogRepository,
 })

--- a/src/controllers/CallController.ts
+++ b/src/controllers/CallController.ts
@@ -1,0 +1,69 @@
+// src/controllers/CallController.ts
+import { Response } from "express";
+import { container } from "tsyringe";
+import { CallLogService } from "../business/services/CallLogService";
+import { AuthenticatedRequest } from "../middleware/auth";
+
+export class CallController {
+    private readonly callLogService: CallLogService;
+
+    constructor() {
+        this.callLogService = container.resolve(CallLogService);
+    }
+
+    public async getCallerNumbers(req: AuthenticatedRequest, res: Response) {
+        try {
+            const companyId = req.companyId;
+            if (!companyId) {
+                res.status(400).json({ message: "Missing authenticated company." });
+                return;
+            }
+
+            const rawLimit = req.query.limit;
+            const parsedLimit =
+                typeof rawLimit === "string" && rawLimit.trim().length
+                    ? Number(rawLimit)
+                    : Array.isArray(rawLimit)
+                        ? Number(rawLimit.find((value) => value && value.trim().length) ?? NaN)
+                        : NaN;
+            const limit = Number.isFinite(parsedLimit) && parsedLimit > 0 ? parsedLimit : undefined;
+
+            const numbers = await this.callLogService.getCallerNumbers(companyId, limit);
+            res.json({ phoneNumbers: numbers });
+        } catch (error) {
+            console.error("Failed to fetch caller numbers", error);
+            res.status(500).json({ message: "Failed to fetch caller numbers." });
+        }
+    }
+
+    public async getCallDetails(req: AuthenticatedRequest, res: Response) {
+        try {
+            const companyId = req.companyId;
+            if (!companyId) {
+                res.status(400).json({ message: "Missing authenticated company." });
+                return;
+            }
+
+            const { callSid } = req.params;
+            if (!callSid) {
+                res.status(400).json({ message: "callSid parameter is required." });
+                return;
+            }
+
+            const details = await this.callLogService.getCallDetails(companyId, callSid);
+            res.json(details);
+        } catch (error) {
+            const message = error instanceof Error ? error.message : "Failed to fetch call details.";
+            const lowered = message.toLowerCase();
+            const status = lowered.includes("not found")
+                ? 404
+                : lowered.includes("no vapi")
+                    ? 409
+                    : 400;
+            if (status >= 500 || (!lowered.includes("no vapi") && status !== 404)) {
+                console.error("Failed to fetch call details", error);
+            }
+            res.status(status).json({ message });
+        }
+    }
+}

--- a/src/controllers/VoiceController.ts
+++ b/src/controllers/VoiceController.ts
@@ -15,7 +15,15 @@ export class VoiceController {
         const websocketUrl = serverUrl.replace(/^http/, "ws");
 
         const to = req.body.To;
-        const websocketUrlWithParams = `${websocketUrl}/ws?to=${encodeURIComponent(to)}`;
+        const from = req.body.From;
+        const params = new URLSearchParams();
+        if (typeof to === "string" && to.length > 0) {
+            params.set("to", to);
+        }
+        if (typeof from === "string" && from.length > 0) {
+            params.set("from", from);
+        }
+        const websocketUrlWithParams = `${websocketUrl}/ws?${params.toString()}`;
         console.log(`📞 Initiating stream to: ${websocketUrlWithParams}`);
 
         // Start de stream

--- a/src/data/interfaces/ICallLogRepository.ts
+++ b/src/data/interfaces/ICallLogRepository.ts
@@ -1,0 +1,24 @@
+// src/data/interfaces/ICallLogRepository.ts
+export type CallLogRecord = {
+    companyId: bigint;
+    callSid: string;
+    fromNumber: string | null;
+    vapiCallId: string | null;
+    startedAt: Date;
+    endedAt: Date | null;
+};
+
+export interface ICallLogRepository {
+    upsertCallLog(
+        companyId: bigint,
+        callSid: string,
+        fromNumber: string | null,
+        vapiCallId: string | null,
+        startedAt: Date,
+        endedAt: Date
+    ): Promise<void>;
+
+    getDistinctCallerNumbers(companyId: bigint, limit: number): Promise<string[]>;
+
+    getCallBySid(companyId: bigint, callSid: string): Promise<CallLogRecord | null>;
+}

--- a/src/data/repositories/CallLogRepository.ts
+++ b/src/data/repositories/CallLogRepository.ts
@@ -1,0 +1,81 @@
+// src/data/repositories/CallLogRepository.ts
+import { ResultSetHeader, RowDataPacket } from "mysql2";
+import { ICallLogRepository, CallLogRecord } from "../interfaces/ICallLogRepository";
+import { BaseRepository } from "./BaseRepository";
+
+export class CallLogRepository extends BaseRepository implements ICallLogRepository {
+    public async upsertCallLog(
+        companyId: bigint,
+        callSid: string,
+        fromNumber: string | null,
+        vapiCallId: string | null,
+        startedAt: Date,
+        endedAt: Date
+    ): Promise<void> {
+        const sql = `
+            INSERT INTO company_call_sessions
+                (company_id, call_sid, from_number, vapi_call_id, started_at, ended_at, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, NOW(), NOW())
+            ON DUPLICATE KEY UPDATE
+                from_number = VALUES(from_number),
+                vapi_call_id = VALUES(vapi_call_id),
+                started_at = VALUES(started_at),
+                ended_at = VALUES(ended_at),
+                updated_at = NOW()
+        `;
+
+        await this.execute<ResultSetHeader>(sql, [
+            companyId,
+            callSid,
+            fromNumber,
+            vapiCallId,
+            startedAt,
+            endedAt,
+        ]);
+    }
+
+    public async getDistinctCallerNumbers(companyId: bigint, limit: number): Promise<string[]> {
+        const normalizedLimit = Number.isFinite(limit) && limit > 0 ? Math.min(Math.floor(limit), 200) : 50;
+        const sql = `
+            SELECT from_number, MAX(started_at) AS last_started
+            FROM company_call_sessions
+            WHERE company_id = ?
+              AND from_number IS NOT NULL
+              AND from_number <> ''
+            GROUP BY from_number
+            ORDER BY last_started DESC
+            LIMIT ?
+        `;
+
+        const rows = await this.execute<RowDataPacket[]>(sql, [companyId, normalizedLimit]);
+        return rows
+            .map((row) => row.from_number as string | null)
+            .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+            .map((value) => value.trim());
+    }
+
+    public async getCallBySid(companyId: bigint, callSid: string): Promise<CallLogRecord | null> {
+        const sql = `
+            SELECT company_id, call_sid, from_number, vapi_call_id, started_at, ended_at
+            FROM company_call_sessions
+            WHERE company_id = ?
+              AND call_sid = ?
+            LIMIT 1
+        `;
+
+        const rows = await this.execute<RowDataPacket[]>(sql, [companyId, callSid]);
+        if (rows.length === 0) {
+            return null;
+        }
+
+        const row = rows[0];
+        return {
+            companyId: BigInt(row.company_id),
+            callSid: row.call_sid as string,
+            fromNumber: (row.from_number as string | null) ?? null,
+            vapiCallId: (row.vapi_call_id as string | null) ?? null,
+            startedAt: row.started_at as Date,
+            endedAt: (row.ended_at as Date | null) ?? null,
+        };
+    }
+}

--- a/src/routes/CallRoute.ts
+++ b/src/routes/CallRoute.ts
@@ -1,0 +1,12 @@
+// src/routes/CallRoute.ts
+import { Router } from "express";
+import { authenticateToken } from "../middleware/auth";
+import { CallController } from "../controllers/CallController";
+
+const router = Router();
+const controller = new CallController();
+
+router.get("/phone-numbers", authenticateToken, controller.getCallerNumbers.bind(controller));
+router.get("/:callSid", authenticateToken, controller.getCallDetails.bind(controller));
+
+export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,6 +13,7 @@ import outlookRoute from "./routes/OutlookRoute";
 import integrationRoute from "./routes/IntegrationRoute";
 import updateRoute from "./routes/UpdateRoute";
 import schedulingRoute from "./routes/SchedulingRoute";
+import callRoute from "./routes/CallRoute";
 
 const app = express();
 
@@ -32,6 +33,7 @@ app.use("/outlook", outlookRoute)
 app.use("/integrations", integrationRoute)
 app.use("/updates", updateRoute)
 app.use("/scheduling", schedulingRoute)
+app.use("/calls", callRoute)
 
 const server = createServer(app);
 const webSocketServer = container.resolve(WebSocketServer);

--- a/test/call-flow.test.ts
+++ b/test/call-flow.test.ts
@@ -80,7 +80,8 @@ describe('WebSocketServer Call Flow', () => {
             mockWs,
             'call123',
             'stream456',
-            '+1234567890',
+            '1234567890',
+            undefined,
             startEvent
         );
         expect(mockWs.removeListener).toHaveBeenCalledWith('message', messageCallback);
@@ -162,7 +163,8 @@ describe('WebSocketServer Call Flow', () => {
             mockWs,
             'call123',
             'stream456',
-            '+1987654321',
+            '1987654321',
+            undefined,
             startEvent
         );
     });

--- a/test/jest.setup.ts
+++ b/test/jest.setup.ts
@@ -1,0 +1,11 @@
+process.env.OPENAI_API_KEY = process.env.OPENAI_API_KEY || "test-openai";
+process.env.ELEVENLABS_API_KEY = process.env.ELEVENLABS_API_KEY || "test-elevenlabs";
+process.env.ELEVENLABS_VOICE_ID = process.env.ELEVENLABS_VOICE_ID || "test-voice";
+process.env.TWILIO_SID = process.env.TWILIO_SID || "test-twilio-sid";
+process.env.TWILIO_AUTH = process.env.TWILIO_AUTH || "test-twilio-auth";
+process.env.SERVER_URL = process.env.SERVER_URL || "http://localhost:3003";
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-jwt-secret";
+process.env.MASTER_KEY =
+    process.env.MASTER_KEY || "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+process.env.GOOGLE_REDIRECT_URI = process.env.GOOGLE_REDIRECT_URI || "http://localhost:3000";
+process.env.OUTLOOK_REDIRECT_URI = process.env.OUTLOOK_REDIRECT_URI || "http://localhost:3000";


### PR DESCRIPTION
## Summary
- persist Vapi call identifiers and Twilio caller numbers when voice sessions stop so we can look up call details later
- add a CallLog service/repository along with authenticated API routes to list caller numbers and fetch Vapi call details
- plumb caller metadata through the Twilio websocket handshake, expose the new routes, and configure Jest with test env secrets

## Testing
- `npm test -- --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68e5148b79d48327909de09d341db04c