### PR TITLE
Add call lookup endpoint by phone number

### DIFF
--- a/src/business/services/CallLogService.ts
+++ b/src/business/services/CallLogService.ts
@@ -18,6 +18,12 @@ export type CallDetailsResponse = {
     messages: CallTranscriptMessage[];
 };
 
+export type CallSummaryResponse = {
+    callSid: string;
+    phoneNumber: string | null;
+    startedAt: Date;
+};
+
 @injectable()
 export class CallLogService {
     constructor(
@@ -45,6 +51,27 @@ export class CallLogService {
 
     public async getCallerNumbers(companyId: bigint, limit?: number): Promise<string[]> {
         return this.callLogRepository.getDistinctCallerNumbers(companyId, limit ?? 50);
+    }
+
+    public async getCallsByPhoneNumber(
+        companyId: bigint,
+        phoneNumber: string
+    ): Promise<CallSummaryResponse[]> {
+        const trimmedPhoneNumber = phoneNumber.trim();
+        if (!trimmedPhoneNumber) {
+            return [];
+        }
+
+        const records = await this.callLogRepository.getCallsByPhoneNumber(
+            companyId,
+            trimmedPhoneNumber
+        );
+
+        return records.map((record) => ({
+            callSid: record.callSid,
+            phoneNumber: record.fromNumber,
+            startedAt: record.startedAt,
+        }));
     }
 
     public async getCallDetails(companyId: bigint, callSid: string): Promise<CallDetailsResponse> {

--- a/src/controllers/CallController.ts
+++ b/src/controllers/CallController.ts
@@ -44,6 +44,30 @@ export class CallController {
         }
     }
 
+    public async getCallsByPhoneNumber(req: AuthenticatedRequest, res: Response) {
+        try {
+            const companyId = req.companyId;
+            if (!companyId) {
+                res.status(400).json({ message: "Missing authenticated company." });
+                return;
+            }
+
+            const rawPhoneNumber = req.query.phoneNumber;
+            const phoneNumber = typeof rawPhoneNumber === "string" ? rawPhoneNumber.trim() : "";
+
+            if (!phoneNumber) {
+                res.status(400).json({ message: "phoneNumber query parameter is required." });
+                return;
+            }
+
+            const calls = await this.callLogService.getCallsByPhoneNumber(companyId, phoneNumber);
+            res.json({ calls });
+        } catch (error) {
+            console.error("Failed to fetch calls by phone number", error);
+            res.status(500).json({ message: "Failed to fetch calls by phone number." });
+        }
+    }
+
 
     public async getCallDetails(req: AuthenticatedRequest, res: Response) {
         try {

--- a/src/data/interfaces/ICallLogRepository.ts
+++ b/src/data/interfaces/ICallLogRepository.ts
@@ -21,4 +21,6 @@ export interface ICallLogRepository {
     getDistinctCallerNumbers(companyId: bigint, limit: number): Promise<string[]>;
 
     getCallBySid(companyId: bigint, callSid: string): Promise<CallLogRecord | null>;
+
+    getCallsByPhoneNumber(companyId: bigint, phoneNumber: string): Promise<CallLogRecord[]>;
 }

--- a/src/data/repositories/CallLogRepository.ts
+++ b/src/data/repositories/CallLogRepository.ts
@@ -78,4 +78,27 @@ export class CallLogRepository extends BaseRepository implements ICallLogReposit
             endedAt: (row.ended_at as Date | null) ?? null,
         };
     }
+
+    public async getCallsByPhoneNumber(
+        companyId: bigint,
+        phoneNumber: string
+    ): Promise<CallLogRecord[]> {
+        const sql = `
+            SELECT company_id, call_sid, from_number, vapi_call_id, started_at, ended_at
+            FROM company_call_sessions
+            WHERE company_id = ?
+              AND from_number = ?
+            ORDER BY started_at DESC
+        `;
+
+        const rows = await this.execute<RowDataPacket[]>(sql, [companyId, phoneNumber]);
+        return rows.map((row) => ({
+            companyId: BigInt(row.company_id),
+            callSid: row.call_sid as string,
+            fromNumber: (row.from_number as string | null) ?? null,
+            vapiCallId: (row.vapi_call_id as string | null) ?? null,
+            startedAt: row.started_at as Date,
+            endedAt: (row.ended_at as Date | null) ?? null,
+        }));
+    }
 }

--- a/src/routes/CallRoute.ts
+++ b/src/routes/CallRoute.ts
@@ -7,6 +7,7 @@ const router = Router();
 const controller = new CallController();
 
 router.get("/phone-numbers", authenticateToken, controller.getCallerNumbers.bind(controller));
+router.get("/by-phone-number", authenticateToken, controller.getCallsByPhoneNumber.bind(controller));
 router.get("/:callSid", authenticateToken, controller.getCallDetails.bind(controller));
 
 export default router;


### PR DESCRIPTION
## Summary
- add a CallLogService helper that retrieves recent calls for a given phone number
- expose a new authenticated GET /calls/by-phone-number endpoint returning call SID, phone number, and start date
- extend the call log repository to query call sessions by the caller number

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68e68501c2e483279736716a19f5d440